### PR TITLE
Fix bug in token expiration logic.

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function callCerberus (type, options, keyPath, data, cb) {
 }
 
 function getToken (options, cb) {
-  if (options.tokenExpiresAt && (options.tokenExpiresAt <= ( Date.now() / 1000 ) )) {  // token TTL in secs, Date.now in ms
+  if (options.tokenExpiresAt && (options.tokenExpiresAt <= ( Date.now() / 1000 ) )) {  // tokenExpiresAt in secs, Date.now in ms
     options.tokenExpiresAt = null
     options.token = null
   }

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function callCerberus (type, options, keyPath, data, cb) {
 }
 
 function getToken (options, cb) {
-  if (options.tokenExpiresAt && (options.tokenExpiresAt <= Date.now())) {
+  if (options.tokenExpiresAt && (options.tokenExpiresAt <= ( Date.now() / 1000 ) )) {  // token TTL in secs, Date.now in ms
     options.tokenExpiresAt = null
     options.token = null
   }
@@ -145,7 +145,8 @@ function getCredsToken (options, cb) {
     options.log('user token retrieved', token)
     if (err) return cb(err)
     if (token && token.errors) return cb(token.errors)
-    options.tokenExpiresAt = Date.now + token['lease_duration'] - 600
+    // Expire 10 seconds before lease is up, to account for latency
+    options.tokenExpiresAt = ( Date.now() / 1000 ) + token['lease_duration'] - 10  // token TTL in secs, Date.now in ms
     options.token = token['client_token']
     cb(null, options.token)
   })
@@ -178,7 +179,7 @@ function authenticate (options, accountId, roleName, region, cb) {
       if (err) return cb(err)
       options.log('decrypt result', token)
       // Expire 10 seconds before lease is up, to account for latency
-      options.tokenExpiresAt = Date.now + token['lease_duration'] - 600
+      options.tokenExpiresAt = ( Date.now() / 1000 ) + token['lease_duration'] - 10  // token TTL in secs, Date.now in ms
       options.token = token['client_token']
       cb(null, options.token)
     })


### PR DESCRIPTION
Fixes an issue in the token expiration calculation, so that a new token is retrieved 10 seconds before TTL is up.