### PR TITLE
Increasing token expiration padding from 10 seconds to 60 seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,8 +130,8 @@ function getToken (context, cb) {
 }
 
 function setToken (context, token, cb) {
-  // Expire 10 seconds before lease is up, to account for latency
-  context.tokenExpiresAt = (Date.now() / 1000) + token['lease_duration'] - 10  // token TTL in secs, Date.now in ms
+  // Expire 60 seconds before lease is up, to account for latency
+  context.tokenExpiresAt = (Date.now() / 1000) + token['lease_duration'] - 60  // token TTL in secs, Date.now in ms
   context.token = token['client_token']
   cb(null, context.token)
 }


### PR DESCRIPTION
Increasing token expiration padding from 10 seconds to 60 seconds to match other clients (10 seconds was probably good enough but 60 seconds seems a bit better and matches other clients).