### PR TITLE
* replace new Buffer() with Buffer.from()

### DIFF
--- a/index.js
+++ b/index.js
@@ -335,7 +335,7 @@ function getEnvironmentVariable (value) {
 }
 
 function makeAuthHeader (username, password) {
-  return 'Basic ' + new Buffer(username + ':' + password).toString('base64')
+  return 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
 }
 
 const formatCerberusError = (errors) => {

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const kms = require('./lib/kms')
 const lambda = require('./lib/lambda')
 const sts = require('./lib/sts')
 const FormData = require('form-data')
+const Buffer = require('safe-buffer').Buffer
 const packageData = require('./package.json')
 
 module.exports = cerberus

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -2,6 +2,7 @@
 const co = require('co')
 const aws4 = require('aws4')
 const request = require('request-micro')
+const Buffer = require('safe-buffer').Buffer
 
 module.exports = {
   decrypt: decrypt

--- a/lib/kms.js
+++ b/lib/kms.js
@@ -27,7 +27,7 @@ function decrypt (text, options) {
       throw new Error('You do not have access to the KMS key required for authentication. The most likely cause is that your IAM role does not have the KMS Decrypt action. You will need to add it to your role.')
     }
     try {
-      return JSON.parse(new Buffer(result.Plaintext, 'base64').toString())
+      return JSON.parse(Buffer.from(result.Plaintext, 'base64').toString())
     } catch (e) {
       throw new Error('Error parsing KMS decrypt Result. ' + e.message)
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4287,6 +4287,14 @@
         "safe-buffer": "~5.0.1",
         "string_decoder": "~1.0.0",
         "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        }
       }
     },
     "readdirp": {
@@ -4423,10 +4431,9 @@
       "dev": true
     },
     "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
-      "dev": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "samsam": {
       "version": "1.2.1",
@@ -4579,6 +4586,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+          "dev": true
+        }
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "co": "^4.6.0",
     "form-data": "^2.3.2",
     "request-micro": "^1.3.0",
+    "safe-buffer": "^5.1.2",
     "url-join": "^1.1.0"
   },
   "devDependencies": {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -5,6 +5,7 @@
 let sinon = require('sinon')
 let test = require('blue-tape')
 let http = require('http')
+let Buffer = require('safe-buffer').Buffer
 
 let linereader = require('../lib/linereader')
 let lambda = require('../lib/lambda')

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -26,7 +26,7 @@ function trimRequest (req) {
   }
 }
 let defaultCerberusResponse = {
-  auth_data: new Buffer('test').toString('base64')
+  auth_data: Buffer.from('test').toString('base64')
 }
 let defaultToken = {
   'client_token': Math.floor(Math.random() * (1e6 + 1)),
@@ -224,7 +224,7 @@ test('Apps put', spec => {
     const handler = (req, res) => {
       res.setHeader('Content-Type', 'application/json')
       if (req.url.indexOf('auth/user') !== -1) {
-        t.equal('Basic ' + new Buffer('user:password').toString('base64'), req.headers.authorization, 'sent prompted credentials')
+        t.equal('Basic ' + Buffer.from('user:password').toString('base64'), req.headers.authorization, 'sent prompted credentials')
         res.end(JSON.stringify({ data: { client_token: defaultToken } }))
       } else {
         res.end(JSON.stringify(defaultCerberusResponse))


### PR DESCRIPTION
Auth with Cerberus generates following warning message:
`(node:16580) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.`
Therefore it's replaced by the recommended Buffer.from() along with several other places.
See link below for detail info about new Buffer()'s security risk
https://github.com/feross/safe-buffer